### PR TITLE
Avoid overwriting attributes on different classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
 - 2.0.0
 - 2.1.4
+- 2.2.0
 script: bundle exec rspec
 addons:
   code_climate:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rvm:
 - 2.0.0
 - 2.1.4
 - 2.2.0
+before_install:
+  - gem update bundler
 script: bundle exec rspec
 addons:
   code_climate:

--- a/attribute_helpers.gemspec
+++ b/attribute_helpers.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.1"
   spec.add_development_dependency "rubocop", "~> 0.28"
   spec.add_development_dependency "temping", "~> 3.2"
+  spec.add_development_dependency "sqlite3", "~> 1.3"
 end

--- a/lib/attribute_helpers.rb
+++ b/lib/attribute_helpers.rb
@@ -6,60 +6,41 @@ require "attribute_helpers/version"
 # the database and your application code.
 
 module AttributeHelpers
-  # This module needs to be prepended to work in ActiveRecord classes. This is
-  # because ActiveRecord doesn't have accessors/mutators defined until an
-  # instance is created, which means we need to use the prepend + super()
-  # pattern because attempts to use instance_method + binding will fail since
-  # instance_method will not find the method in the class context as it will not
-  # exist until it is dynamically created when an instance is created. Prepend
-  # works for us because it inserts the behavior *below* the class in the
-  # inheritance hierarchy, so we can access the default ActiveRecord accessors/
-  # mutators through the use of super().
-  # More information here: http://stackoverflow.com/a/4471202/1103543
-  def self.prepended(klass)
-    # We need to store the module in a variable for use when we're in the class
-    # context.
-    me = self
-
-    # Marks attributes as storing symbol values, providing setters and getters
-    # for the attributes that will allow the application to use them as symbols
-    # but store them internally as strings.
-    # @param attrs [*Symbol] a list of the attributes that store symbols
-    klass.define_singleton_method :attr_symbol do |*attrs|
-      # Overwrite each attribute's methods.
+  def attr_symbol(*attrs)
+    translator = Module.new do
       attrs.each do |attr|
         # Overwrite the accessor.
-        me.send(:define_method, attr) do
+        define_method(attr) do
           val = super()
           val && val.to_sym
         end
 
         # Overwrite the mutator.
-        me.send(:define_method, "#{attr}=") do |val|
+        define_method("#{attr}=") do |val|
           super(val && val.to_s)
         end
       end
     end
 
-    # Marks attributes as storing class values, providing setters and getters
-    # for the attributes that will allow the application to use them as classes
-    # but store them internally as strings.
-    # @param attrs [*Symbol] a list of the attributes that store classes
-    klass.define_singleton_method :attr_class do |*attrs|
-      # Overwrite each attribute's methods.
+    prepend translator
+  end
+
+  def attr_class(*attrs)
+    translator = Module.new do
       attrs.each do |attr|
         # Overwrite the accessor.
-        # @raise [NameError] if the string can't be constantized
-        me.send(:define_method, attr) do
+        define_method(attr) do
           val = super()
           val && Kernel.const_get(val)
         end
 
         # Overwrite the mutator.
-        me.send(:define_method, "#{attr}=") do |val|
+        define_method("#{attr}=") do |val|
           super(val && val.to_s)
         end
       end
     end
+
+    prepend translator
   end
 end

--- a/spec/active_record_class_spec.rb
+++ b/spec/active_record_class_spec.rb
@@ -3,14 +3,28 @@ require "spec_helper"
 RSpec.context "in an ActiveRecord class" do
   Temping.create :active_record_test_class do
     with_columns do |t|
+      t.integer :other_symbol_attr
+      t.integer :other_class_attr
       t.string :symbol_attr
       t.string :class_attr
     end
 
-    prepend AttributeHelpers
+    extend AttributeHelpers
 
     attr_symbol :symbol_attr
     attr_class :class_attr
+  end
+
+  Temping.create :other_active_record_test_class do
+    with_columns do |t|
+      t.string :other_symbol_attr
+      t.string :other_class_attr
+    end
+
+    extend AttributeHelpers
+
+    attr_symbol :other_symbol_attr
+    attr_class :other_class_attr
   end
 
   let(:test_obj) { ActiveRecordTestClass.new }
@@ -46,6 +60,13 @@ RSpec.context "in an ActiveRecord class" do
 
         test_obj.symbol_attr = nil
         expect(test_obj[:symbol_attr]).to be_nil
+      end
+    end
+
+    context "with attributes that overlap with another class" do
+      it "does not overwrite other attributes" do
+        test_obj.other_symbol_attr = 12345
+        expect(test_obj.other_symbol_attr).to eq 12345
       end
     end
   end
@@ -92,6 +113,13 @@ RSpec.context "in an ActiveRecord class" do
 
         test_obj.class_attr = nil
         expect(test_obj[:class_attr]).to be_nil
+      end
+    end
+
+    context "with attributes that overlap with another class" do
+      it "does not overwrite other attributes" do
+        test_obj.other_class_attr = 12345
+        expect(test_obj.other_class_attr).to eq 12345
       end
     end
   end

--- a/spec/ruby_class_spec.rb
+++ b/spec/ruby_class_spec.rb
@@ -2,13 +2,25 @@ require "spec_helper"
 
 RSpec.context "in a pure Ruby class" do
   class RubyTestClass
-    prepend AttributeHelpers
+    extend AttributeHelpers
 
     attr_accessor :symbol_attr
     attr_accessor :class_attr
+    attr_accessor :other_symbol_attr
+    attr_accessor :other_class_attr
 
     attr_symbol :symbol_attr
     attr_class :class_attr
+  end
+
+  class OtherRubyTestClass
+    extend AttributeHelpers
+
+    attr_accessor :other_symbol_attr
+    attr_accessor :other_class_attr
+
+    attr_symbol :other_symbol_attr
+    attr_class :other_class_attr
   end
 
   let(:test_obj) { RubyTestClass.new }
@@ -16,7 +28,7 @@ RSpec.context "in a pure Ruby class" do
   describe ".attr_symbol" do
     describe "getter" do
       it "translates string to symbol" do
-        # Give it an intial value to be read.
+        # Give it an initial value to be read.
         test_obj.instance_variable_set(:@symbol_attr, "example")
 
         expect(test_obj.symbol_attr).to eq :example
@@ -44,6 +56,13 @@ RSpec.context "in a pure Ruby class" do
 
         test_obj.symbol_attr = nil
         expect(test_obj.instance_variable_get(:@symbol_attr)).to be_nil
+      end
+    end
+
+    context "with attributes that overlap with another class" do
+      it "does not overwrite other attributes" do
+        test_obj.other_symbol_attr = 12345
+        expect(test_obj.other_symbol_attr).to eq 12345
       end
     end
   end
@@ -90,6 +109,13 @@ RSpec.context "in a pure Ruby class" do
 
         test_obj.class_attr = nil
         expect(test_obj.instance_variable_get(:@class_attr)).to be_nil
+      end
+    end
+
+    context "with attributes that overlap with another class" do
+      it "does not overwrite other attributes" do
+        test_obj.other_class_attr = 12345
+        expect(test_obj.other_class_attr).to eq 12345
       end
     end
   end


### PR DESCRIPTION
If you have the same attribute name in two classes, and it's marked as
an attr_(class|symbol) in one of the classes, this helper currently
sets the attribute as a symbol in both classes.

This leads to unexpected behavior and should be fixed.

@JacobEvelyn