### PR TITLE
Update Rubocop for CVE-2017-8418

### DIFF
--- a/attribute_helpers.gemspec
+++ b/attribute_helpers.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "overcommit", "~> 0.21"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.1"
-  spec.add_development_dependency "rubocop", "~> 0.28"
+  spec.add_development_dependency "rubocop", "~> 0.49"
   spec.add_development_dependency "temping", "~> 3.2"
   spec.add_development_dependency "sqlite3", "~> 1.3"
 end


### PR DESCRIPTION
This is to fix the big scary warning on [this page](https://github.com/panorama-ed/attribute_helpers).